### PR TITLE
JNG-4413 API and IMPL export same package fixed

### DIFF
--- a/osgi-api/pom.xml
+++ b/osgi-api/pom.xml
@@ -30,6 +30,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>hu.blackbelt.osgi.utils.osgi.api</Export-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/osgi-impl/pom.xml
+++ b/osgi-impl/pom.xml
@@ -27,6 +27,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>hu.blackbelt.osgi.utils.internal.impl</Export-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4413" title="JNG-4413" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4413</a>  osgi-utils impl export api package which causes OSGI same package export problem
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
